### PR TITLE
feature/round1-users

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/users/UsersFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/users/UsersFacade.java
@@ -1,0 +1,28 @@
+package com.loopers.application.users;
+
+import com.loopers.domain.users.UsersModel;
+import com.loopers.domain.users.UsersService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.type.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UsersFacade {
+    private final UsersService usersService;
+
+    public UsersInfo register(String loginId, Gender gender, String birthDate, String email) {
+        UsersModel model = usersService.register(loginId, gender, birthDate, email);
+        return UsersInfo.from(model);
+    }
+
+    public UsersInfo getMyInfo(String loginId) {
+        UsersModel model = usersService.getMyInfo(loginId);
+        if (model == null) {
+            throw new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다: " + loginId);
+        }
+        return UsersInfo.from(model);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/users/UsersInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/users/UsersInfo.java
@@ -1,0 +1,21 @@
+package com.loopers.application.users;
+
+import com.loopers.domain.users.UsersModel;
+
+public record UsersInfo (
+        Long id,
+        String loginId,
+        String gender,
+        String birthDate,
+        String email
+) {
+    public static UsersInfo from(UsersModel model) {
+        return new UsersInfo(
+                model.getId(),
+                model.getLoginId(),
+                model.getGender().getValue(),
+                model.getBirthDate(),
+                model.getEmail()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/users/UsersModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/users/UsersModel.java
@@ -1,0 +1,81 @@
+package com.loopers.domain.users;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.type.Gender;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+
+@Getter
+@Slf4j
+@Entity
+@Table(name = "users")
+public class UsersModel extends BaseEntity {
+
+    private String loginId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender", nullable = false, length = 20)
+    private Gender gender;
+
+    private String birthDate;
+
+    private String email;
+
+    protected UsersModel() {}
+
+    public UsersModel(String loginId, Gender gender, String birthDate, String email) {
+        super();
+        validateLoginId(loginId);
+        validateBirthDate(birthDate);
+        validateEmail(email);
+        this.loginId = loginId;
+        this.gender = gender;
+        this.birthDate = birthDate;
+        this.email = email;
+    }
+
+    public static UsersModel of(String loginId, Gender gender, String birthDate, String email) {
+        return new UsersModel(loginId, gender, birthDate, email);
+    }
+
+    private void validateLoginId(String loginId) {
+        if (loginId == null || loginId.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "아이디는 비어있을 수 없습니다: " + loginId);
+        }
+        if (loginId.length() > 10) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "아이디는 10자 이하여야 합니다: " + loginId);
+        }
+    }
+
+    private void validateBirthDate(String birthDate) {
+        if (birthDate == null || birthDate.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 비어있을 수 없습니다: " + birthDate);
+        }
+        if (!birthDate.matches("\\d{4}-\\d{2}-\\d{2}")) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 yyyy-MM-dd 형식이어야 합니다: " + birthDate);
+        }
+        try {
+            LocalDate.parse(birthDate);
+        } catch (DateTimeException e) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 yyyy-MM-dd 형식이어야 합니다: " + birthDate);
+        }
+        if (LocalDate.now().isBefore(LocalDate.parse(birthDate))) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 오늘 이전이어야 합니다: " + birthDate);
+        }
+    }
+
+    private void validateEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이메일은 비어있을 수 없습니다: " + email);
+        }
+        if (!email.matches("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이메일은 올바른 형식이어야 합니다: " + email);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/users/UsersRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/users/UsersRepository.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.users;
+
+import java.util.Optional;
+
+public interface UsersRepository {
+    UsersModel save(UsersModel model);
+    boolean existsByLoginId(String loginId);
+
+
+    default UsersModel getByLoginId(String loginId){
+        return findByLoginId(loginId)
+                .orElse(null);
+    }
+
+    Optional<UsersModel> findByLoginId(String loginId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/users/UsersService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/users/UsersService.java
@@ -1,0 +1,30 @@
+package com.loopers.domain.users;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.type.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class UsersService {
+
+    private final UsersRepository usersRepository;
+
+    @Transactional
+    public UsersModel register(String loginId, Gender gender, String birthDate, String email) {
+        if (usersRepository.existsByLoginId(loginId)) {
+            throw new CoreException(ErrorType.CONFLICT, "이미 존재하는 로그인 ID입니다.");
+        }
+
+        UsersModel usersModel = UsersModel.of(loginId, gender, birthDate, email);
+        return usersRepository.save(usersModel);
+    }
+
+    @Transactional(readOnly = true)
+    public UsersModel getMyInfo(String loginId) {
+        return usersRepository.getByLoginId(loginId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/users/UsersJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/users/UsersJpaRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.infrastructure.users;
+
+import com.loopers.domain.users.UsersModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UsersJpaRepository extends JpaRepository<UsersModel, Long> {
+    boolean existsByLoginId(String loginId);
+
+    Optional<UsersModel> findByLoginId(String loginId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/users/UsersRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/users/UsersRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.loopers.infrastructure.users;
+
+import com.loopers.domain.users.UsersModel;
+import com.loopers.domain.users.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class UsersRepositoryImpl implements UsersRepository {
+    private final UsersJpaRepository jpaRepository;
+
+    @Override
+    public UsersModel save(UsersModel model) {
+        return jpaRepository.save(model);
+    }
+
+    @Override
+    public boolean existsByLoginId(String loginId) {
+        return jpaRepository.existsByLoginId(loginId);
+    }
+
+    @Override
+    public Optional<UsersModel> findByLoginId(String loginId) {
+        return jpaRepository.findByLoginId(loginId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/users/UsersV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/users/UsersV1ApiSpec.java
@@ -1,0 +1,26 @@
+package com.loopers.interfaces.api.users;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Users V1 API", description = "회원가입, 내 정보 조회")
+public interface UsersV1ApiSpec {
+    @Operation(
+            summary = "회원가입",
+            description = "회원가입"
+    )
+    ApiResponse<UsersV1Dto.UsersResponse> register(
+            @Schema(name = "요청", description = "회원가입할 사용자 정보 입력")
+            UsersV1Dto.UsersRegisterRequest request
+    );
+
+    @Operation(
+            summary = "내 정보 조회",
+            description = "내 정보 조회"
+    )
+    ApiResponse<UsersV1Dto.UsersResponse> getMyInfo(
+            @Schema(name = "조회할 아이디", description = "X-USER-ID") String loginId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/users/UsersV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/users/UsersV1Controller.java
@@ -1,0 +1,41 @@
+package com.loopers.interfaces.api.users;
+
+import com.loopers.application.users.UsersFacade;
+import com.loopers.application.users.UsersInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.type.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
+public class UsersV1Controller implements UsersV1ApiSpec {
+
+    private final UsersFacade usersFacade;
+
+    @PostMapping("")
+    @Override
+    public ApiResponse<UsersV1Dto.UsersResponse> register(
+            @RequestBody UsersV1Dto.UsersRegisterRequest request
+    ) {
+        UsersInfo info = usersFacade.register(
+                request.loginId(),
+                Gender.from(request.gender()),
+                request.birthDate(),
+                request.email());
+        UsersV1Dto.UsersResponse response = UsersV1Dto.UsersResponse.from(info);
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/me")
+    @Override
+    public ApiResponse<UsersV1Dto.UsersResponse> getMyInfo(
+            @RequestHeader("X-USER-ID") String loginId
+    ) {
+        UsersInfo info = usersFacade.getMyInfo(loginId);
+        UsersV1Dto.UsersResponse response = UsersV1Dto.UsersResponse.from(info);
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/users/UsersV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/users/UsersV1Dto.java
@@ -1,0 +1,25 @@
+package com.loopers.interfaces.api.users;
+
+import com.loopers.application.users.UsersInfo;
+
+public class UsersV1Dto {
+    public record UsersResponse(
+            Long id, String loginId, String gender, String birthDate, String email
+    ) {
+        public static UsersResponse from(UsersInfo info) {
+            return new UsersResponse(
+                info.id(),
+                info.loginId(),
+                info.gender(),
+                info.birthDate(),
+                info.email()
+            );
+        }
+    }
+
+
+    public record UsersRegisterRequest(
+            String loginId, String gender, String birthDate, String email
+    ) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/type/Gender.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/type/Gender.java
@@ -1,0 +1,30 @@
+package com.loopers.support.type;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.Getter;
+
+@Getter
+public enum Gender {
+    MALE("남"),
+    FEMALE("여"),
+    ;
+
+    private final String value;
+
+    Gender(String value) {
+        this.value = value;
+    }
+
+    public static Gender from(String value) {
+        if (value == null || value.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "성별은 비어있을 수 없습니다: " + value);
+        }
+        
+        return switch (value) {
+            case "남" -> MALE;
+            case "여" -> FEMALE;
+            default -> throw new CoreException(ErrorType.BAD_REQUEST, "지원하지 않는 성별입니다: " + value);
+        };
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/users/UsersModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/users/UsersModelTest.java
@@ -1,0 +1,70 @@
+package com.loopers.domain.users;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.type.Gender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UsersModelTest {
+    @Nested
+    class Create {
+        @DisplayName("ID 가 영문 및 숫자 10자 이내 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+        @Test
+        void failsToCreateUser_whenLoginIdIsInvalid() {
+            // arrange
+            String invalidLoginId = "invalid_login_id";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                UsersModel.of(invalidLoginId,
+                        Gender.MALE,
+                        "1993-04-09",
+                        "test@gmail.com");
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("이메일이 xx@yy.zz 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+        @Test
+        void failsToCreateUser_whenEmailIsInvalid() {
+            // arrange
+            String invalidEmail = "invalid_email_format";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                UsersModel.of("testUser",
+                        Gender.MALE,
+                        "1993-04-09",
+                        invalidEmail);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("생년월일이 yyyy-MM-dd 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+        @Test
+        void failsToCreateUser_whenBirthDateIsInvalid() {
+            // arrange
+            String invalidBirthDate = "19931230"; // 잘못된 날짜 형식
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                UsersModel.of("testUser",
+                        Gender.MALE,
+                        invalidBirthDate,
+                        "test@gmail.com");
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/users/UsersServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/users/UsersServiceTest.java
@@ -1,0 +1,119 @@
+package com.loopers.domain.users;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.type.Gender;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class UsersServiceTest {
+
+    @Autowired
+    private UsersService usersService;
+    @Autowired
+    private UsersRepository usersRepository;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+    
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    @DisplayName("회원가입")
+    class register {
+        @Test
+        @DisplayName("회원 가입시 User 저장이 수행된다. ( spy 검증 )")
+        void saveUser_whenUserRegisters() {
+            var spyUsersRepository = spy(usersRepository);
+            UsersService spyUsersService = new UsersService(spyUsersRepository);
+
+            // act
+            UsersModel result = spyUsersService.register("testUser",
+                    Gender.MALE,
+                    "1993-04-09",
+                    "test@gmail.com");
+
+            // verify
+            verify(spyUsersRepository).existsByLoginId("testUser");
+            verify(spyUsersRepository).save(any(UsersModel.class));
+            assertNotNull(result);
+            assertEquals("testUser", result.getLoginId());
+        }
+
+        @Test
+        @DisplayName("이미 가입된 ID로 회원가입 시도 시, 실패한다.")
+        void failToRegister_whenLoginIdAlreadyExists() {
+            // arrange
+            usersService.register("testUser",
+                    Gender.MALE,
+                    "1993-04-09",
+                    "test@gmail.com");
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                usersService.register("testUser",
+                        Gender.FEMALE,
+                        "1993-04-09",
+                        "test@naver.com");
+            });
+
+            // assert
+            assertEquals(exception.getErrorType(), ErrorType.CONFLICT);
+        }
+    }
+
+    @Nested
+    @DisplayName("내 정보 조회")
+    class getMyInfo {
+        @Test
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.")
+        void returnsUserInfo_whenUserExists() {
+            // arrange
+            UsersModel expected = UsersModel.of("testUser",
+                    Gender.MALE,
+                    "1993-04-09",
+                    "test@gmail.com");
+            UsersModel savedUser = usersRepository.save(expected);
+            String loginId = savedUser.getLoginId();
+
+            // act
+            UsersModel result = usersService.getMyInfo(loginId);
+
+            // assert
+            assertAll(
+                () -> assertNotNull(result),
+                () -> assertNotNull(result.getId()),
+                () -> assertNotNull(result.getCreatedAt()),
+                () -> assertNotNull(result.getUpdatedAt()),
+                () -> assertEquals(expected.getLoginId(), result.getLoginId()),
+                () -> assertEquals(expected.getGender(), result.getGender()),
+                () -> assertEquals(expected.getBirthDate(), result.getBirthDate()),
+                () -> assertEquals(expected.getEmail(), result.getEmail())
+            );
+        }
+
+        @Test
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        void returnsNull_whenUserDoesNotExist() {
+            // arrange
+            String nonExistentLoginId = "nonExistentUser";
+
+            // act
+            UsersModel result = usersService.getMyInfo(nonExistentLoginId);
+
+            // assert
+            assertNull(result);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/users/UsersV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/users/UsersV1ApiE2ETest.java
@@ -1,0 +1,168 @@
+package com.loopers.interfaces.api.users;
+
+import com.loopers.domain.users.UsersModel;
+import com.loopers.infrastructure.users.UsersJpaRepository;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.type.Gender;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMapAdapter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class UsersV1ApiE2ETest {
+
+    private static final Function<String, String> ENDPOINT = (subRoute) -> "/api/v1/users" + subRoute;
+
+    private final TestRestTemplate testRestTemplate;
+    private final UsersJpaRepository jpaRepository;
+    private final DatabaseCleanUp databaseCleanUp;
+
+
+    @Autowired
+    public UsersV1ApiE2ETest(
+            TestRestTemplate testRestTemplate,
+            UsersJpaRepository jpaRepository,
+            DatabaseCleanUp databaseCleanUp
+    ) {
+        this.testRestTemplate = testRestTemplate;
+        this.jpaRepository = jpaRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("POST /api/v1/users")
+    @Nested
+    class Register {
+        @DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsCreatedUser_whenRegistrationIsSuccessful() {
+            // arrange
+            String requestUrl = ENDPOINT.apply("");
+            UsersV1Dto.UsersRegisterRequest request = new UsersV1Dto.UsersRegisterRequest(
+                "testuser",
+                "남",
+                "1990-01-01",
+                "test@example.com"
+            );
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UsersV1Dto.UsersResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UsersV1Dto.UsersResponse>> response =
+                testRestTemplate.exchange(requestUrl, HttpMethod.POST, new HttpEntity<>(request), responseType);
+
+            System.out.println("Response Status: " + response.getStatusCode());
+            System.out.println("Response Body: " + response.getBody());
+
+            // assert
+            assertTrue(response.getStatusCode().is2xxSuccessful());
+            assertNotNull(response.getBody());
+            assertNotNull(response.getBody().data().id());
+            assertEquals(request.loginId(), response.getBody().data().loginId());
+            assertEquals(request.gender(), response.getBody().data().gender());
+            assertEquals(request.birthDate(), response.getBody().data().birthDate());
+            assertEquals(request.email(), response.getBody().data().email());
+        }
+
+        @DisplayName("회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.")
+        @Test
+        void throwsBadRequest_whenGenderIsInvalid() {
+            // arrange
+            String requestUrl = ENDPOINT.apply("");
+            UsersV1Dto.UsersRegisterRequest request = new UsersV1Dto.UsersRegisterRequest(
+                "testuser",
+                "",
+                "1990-01-01",
+                "test@example.com"
+            );
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UsersV1Dto.UsersResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UsersV1Dto.UsersResponse>> response =
+                testRestTemplate.exchange(requestUrl, HttpMethod.POST, new HttpEntity<>(request), responseType);
+
+            // assert
+            assertTrue(response.getStatusCode().is4xxClientError());
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        }
+    }
+
+    @DisplayName("GET /api/v1/users/me")
+    @Nested
+    class GetMyInfo {
+        @DisplayName("내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsMyInfo_whenRequestIsSuccessful() {
+            // arrange
+            String requestUrl = ENDPOINT.apply("/me");
+            String loginId = "testuser";
+            UsersModel model = UsersModel.of(
+                    loginId,
+                    Gender.MALE,
+                    "1993-04-09",
+                    "test@gmail.com");
+            jpaRepository.save(model);
+            var headers = new MultiValueMapAdapter<>(Map.of("X-USER-ID", List.of(loginId)));
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UsersV1Dto.UsersResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UsersV1Dto.UsersResponse>> response =
+                    testRestTemplate.exchange(
+                            requestUrl,
+                            HttpMethod.GET,
+                            new HttpEntity<>(null, headers),
+                            responseType
+                    );
+
+            // assert
+            assertTrue(response.getStatusCode().is2xxSuccessful());
+            assertNotNull(response.getBody());
+            assertNotNull(response.getBody().data().id());
+            assertEquals(model.getLoginId(), response.getBody().data().loginId());
+            assertEquals(model.getGender().getValue(), response.getBody().data().gender());
+            assertEquals(model.getBirthDate(), response.getBody().data().birthDate());
+            assertEquals(model.getEmail(), response.getBody().data().email());
+        }
+
+        @DisplayName("존재하지 않는 ID 로 조회할 경우, 404 Not Found 응답을 반환한다.")
+        @Test
+        void throwsNotFound_whenUserDoesNotExist() {
+            // arrange
+            String requestUrl = ENDPOINT.apply("/me");
+            String nonExistentLoginId = "nonexistentuser";
+            var headers = new MultiValueMapAdapter<>(Map.of("X-USER-ID", List.of(nonExistentLoginId)));
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UsersV1Dto.UsersResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UsersV1Dto.UsersResponse>> response =
+                    testRestTemplate.exchange(
+                            requestUrl,
+                            HttpMethod.GET,
+                            new HttpEntity<>(null, headers),
+                            responseType
+                    );
+
+            // assert
+            assertTrue(response.getStatusCode().is4xxClientError());
+            assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        }
+
+    }
+}


### PR DESCRIPTION
## 📌 Summary

회원가입, 재 정보 조회에 대한 - 기능 TDD, 도메인 테스트, E2E 테스트

## ✅ Checklist

### 회원 가입

**🧱 단위 테스트**

- [v]  ID 가 `영문 및 숫자 10자 이내` 형식에 맞지 않으면, User 객체 생성에 실패한다.
- [v]  이메일이 `xx@yy.zz` 형식에 맞지 않으면, User 객체 생성에 실패한다.
- [v]  생년월일이 `yyyy-MM-dd` 형식에 맞지 않으면, User 객체 생성에 실패한다.

**🔗 통합 테스트**

- [v] 회원 가입시 User 저장이 수행된다. ( spy 검증 )
- [v] 이미 가입된 ID 로 회원가입 시도 시, 실패한다.

**🌐 E2E 테스트**

- [v] 회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.
- [v] 회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.

### 내 정보 조회

**🔗 통합 테스트**

- [v]  해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.
- [v]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.

**🌐 E2E 테스트**

- [v] 내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환한다.
- [v] 존재하지 않는 ID 로 조회할 경우, `404 Not Found` 응답을 반환한다.
