### PR TITLE
Feature/round1

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/points/PointsFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/points/PointsFacade.java
@@ -1,0 +1,21 @@
+package com.loopers.application.points;
+
+import com.loopers.domain.points.PointsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PointsFacade {
+    private final PointsService pointsService;
+
+    public PointsInfo get(String loginId) {
+        var model = pointsService.get(loginId);
+        return PointsInfo.from(model);
+    }
+
+    public PointsInfo charge(String loginId, Long amount) {
+        var model = pointsService.charge(loginId, amount);
+        return PointsInfo.from(model);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/points/PointsInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/points/PointsInfo.java
@@ -1,0 +1,18 @@
+package com.loopers.application.points;
+
+import com.loopers.domain.points.PointsModel;
+
+public record PointsInfo(
+        Long id,
+        Long userId,
+        Long amount
+) {
+
+    public static PointsInfo from(PointsModel model) {
+        return new PointsInfo(
+                model.getId(),
+                model.getUserId(),
+                model.getAmount()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/users/UsersFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/users/UsersFacade.java
@@ -1,0 +1,28 @@
+package com.loopers.application.users;
+
+import com.loopers.domain.users.UsersModel;
+import com.loopers.domain.users.UsersService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.type.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UsersFacade {
+    private final UsersService usersService;
+
+    public UsersInfo register(String loginId, Gender gender, String birthDate, String email) {
+        UsersModel model = usersService.register(loginId, gender, birthDate, email);
+        return UsersInfo.from(model);
+    }
+
+    public UsersInfo getMyInfo(String loginId) {
+        UsersModel model = usersService.getMyInfo(loginId);
+        if (model == null) {
+            throw new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다: " + loginId);
+        }
+        return UsersInfo.from(model);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/users/UsersInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/users/UsersInfo.java
@@ -1,0 +1,21 @@
+package com.loopers.application.users;
+
+import com.loopers.domain.users.UsersModel;
+
+public record UsersInfo (
+        Long id,
+        String loginId,
+        String gender,
+        String birthDate,
+        String email
+) {
+    public static UsersInfo from(UsersModel model) {
+        return new UsersInfo(
+                model.getId(),
+                model.getLoginId(),
+                model.getGender().getValue(),
+                model.getBirthDate(),
+                model.getEmail()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/points/PointsModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/points/PointsModel.java
@@ -1,0 +1,37 @@
+package com.loopers.domain.points;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "points")
+public class PointsModel extends BaseEntity {
+
+    private Long userId;
+    private Long amount;
+
+    protected PointsModel() {}
+
+    public PointsModel(Long userId, Long amount) {
+        super();
+        this.userId = userId;
+        this.amount = amount;
+    }
+
+    public static PointsModel from(Long userId) {
+        return new PointsModel(userId, 0L);
+    }
+
+    public PointsModel charge(Long amount) {
+        if (amount <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "포인트는 0원 이하가 될 수 없습니다: " + amount);
+        }
+        this.amount += amount;
+        return this;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/points/PointsRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/points/PointsRepository.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.points;
+
+import java.util.Optional;
+
+public interface PointsRepository {
+
+    default PointsModel getByUserId(Long userId){
+        return findByUserId(userId)
+                .orElse(null);
+    }
+
+    Optional<PointsModel> findByUserId(Long id);
+
+    PointsModel save(PointsModel model);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/points/PointsService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/points/PointsService.java
@@ -1,0 +1,39 @@
+package com.loopers.domain.points;
+
+import com.loopers.domain.users.UsersModel;
+import com.loopers.domain.users.UsersRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class PointsService {
+    private final PointsRepository pointsRepository;
+    private final UsersRepository usersRepository;
+
+    @Transactional
+    public PointsModel get(String loginId) {
+        UsersModel user = usersRepository.getByLoginId(loginId);
+        if (user == null) {
+            return null;
+        }
+        PointsModel result = pointsRepository.getByUserId(user.getId());
+        if(result == null) {
+            result = pointsRepository.save(PointsModel.from(user.getId()));
+        }
+        return result;
+    }
+
+    @Transactional
+    public PointsModel charge(String loginId, Long amount) {
+        UsersModel user = usersRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+        PointsModel model = pointsRepository.findByUserId(user.getId())
+                .orElseGet(() -> PointsModel.from(user.getId()));
+        model.charge(amount);
+        return pointsRepository.save(model);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/users/UsersModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/users/UsersModel.java
@@ -1,0 +1,81 @@
+package com.loopers.domain.users;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.type.Gender;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+
+@Getter
+@Slf4j
+@Entity
+@Table(name = "users")
+public class UsersModel extends BaseEntity {
+
+    private String loginId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender", nullable = false, length = 20)
+    private Gender gender;
+
+    private String birthDate;
+
+    private String email;
+
+    protected UsersModel() {}
+
+    public UsersModel(String loginId, Gender gender, String birthDate, String email) {
+        super();
+        validateLoginId(loginId);
+        validateBirthDate(birthDate);
+        validateEmail(email);
+        this.loginId = loginId;
+        this.gender = gender;
+        this.birthDate = birthDate;
+        this.email = email;
+    }
+
+    public static UsersModel of(String loginId, Gender gender, String birthDate, String email) {
+        return new UsersModel(loginId, gender, birthDate, email);
+    }
+
+    private void validateLoginId(String loginId) {
+        if (loginId == null || loginId.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "아이디는 비어있을 수 없습니다: " + loginId);
+        }
+        if (loginId.length() > 10) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "아이디는 10자 이하여야 합니다: " + loginId);
+        }
+    }
+
+    private void validateBirthDate(String birthDate) {
+        if (birthDate == null || birthDate.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 비어있을 수 없습니다: " + birthDate);
+        }
+        if (!birthDate.matches("\\d{4}-\\d{2}-\\d{2}")) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 yyyy-MM-dd 형식이어야 합니다: " + birthDate);
+        }
+        try {
+            LocalDate.parse(birthDate);
+        } catch (DateTimeException e) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 yyyy-MM-dd 형식이어야 합니다: " + birthDate);
+        }
+        if (LocalDate.now().isBefore(LocalDate.parse(birthDate))) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 오늘 이전이어야 합니다: " + birthDate);
+        }
+    }
+
+    private void validateEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이메일은 비어있을 수 없습니다: " + email);
+        }
+        if (!email.matches("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이메일은 올바른 형식이어야 합니다: " + email);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/users/UsersRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/users/UsersRepository.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.users;
+
+import java.util.Optional;
+
+public interface UsersRepository {
+    UsersModel save(UsersModel model);
+    boolean existsByLoginId(String loginId);
+
+
+    default UsersModel getByLoginId(String loginId){
+        return findByLoginId(loginId)
+                .orElse(null);
+    }
+
+    Optional<UsersModel> findByLoginId(String loginId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/users/UsersService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/users/UsersService.java
@@ -1,0 +1,30 @@
+package com.loopers.domain.users;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.type.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class UsersService {
+
+    private final UsersRepository usersRepository;
+
+    @Transactional
+    public UsersModel register(String loginId, Gender gender, String birthDate, String email) {
+        if (usersRepository.existsByLoginId(loginId)) {
+            throw new CoreException(ErrorType.CONFLICT, "이미 존재하는 로그인 ID입니다.");
+        }
+
+        UsersModel usersModel = UsersModel.of(loginId, gender, birthDate, email);
+        return usersRepository.save(usersModel);
+    }
+
+    @Transactional(readOnly = true)
+    public UsersModel getMyInfo(String loginId) {
+        return usersRepository.getByLoginId(loginId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/points/PointsJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/points/PointsJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.points;
+
+import com.loopers.domain.points.PointsModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointsJpaRepository extends JpaRepository<PointsModel, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/points/PointsRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/points/PointsRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.points;
+
+import com.loopers.domain.points.PointsModel;
+import com.loopers.domain.points.PointsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class PointsRepositoryImpl implements PointsRepository {
+
+    private final PointsJpaRepository jpaRepository;
+
+    @Override
+    public Optional<PointsModel> findByUserId(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public PointsModel save(PointsModel model) {
+        return jpaRepository.save(model);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/users/UsersJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/users/UsersJpaRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.infrastructure.users;
+
+import com.loopers.domain.users.UsersModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UsersJpaRepository extends JpaRepository<UsersModel, Long> {
+    boolean existsByLoginId(String loginId);
+
+    Optional<UsersModel> findByLoginId(String loginId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/users/UsersRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/users/UsersRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.loopers.infrastructure.users;
+
+import com.loopers.domain.users.UsersModel;
+import com.loopers.domain.users.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class UsersRepositoryImpl implements UsersRepository {
+    private final UsersJpaRepository jpaRepository;
+
+    @Override
+    public UsersModel save(UsersModel model) {
+        return jpaRepository.save(model);
+    }
+
+    @Override
+    public boolean existsByLoginId(String loginId) {
+        return jpaRepository.existsByLoginId(loginId);
+    }
+
+    @Override
+    public Optional<UsersModel> findByLoginId(String loginId) {
+        return jpaRepository.findByLoginId(loginId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -8,6 +8,7 @@ import com.loopers.support.error.ErrorType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -43,6 +44,14 @@ public class ApiControllerAdvice {
         String name = e.getParameterName();
         String type = e.getParameterType();
         String message = String.format("필수 요청 파라미터 '%s' (타입: %s)가 누락되었습니다.", name, type);
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MissingRequestHeaderException e) {
+        String headerName = e.getHeaderName();
+        String type = e.getHeaderName();
+        String message = String.format("필수 요청 헤더 '%s' (타입: %s)가 누락되었습니다.", headerName, type);
         return failureResponse(ErrorType.BAD_REQUEST, message);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/points/PointsV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/points/PointsV1ApiSpec.java
@@ -1,0 +1,8 @@
+package com.loopers.interfaces.api.points;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Points V1 API", description = "포인트 충전, 조회")
+public interface PointsV1ApiSpec {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/points/PointsV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/points/PointsV1Controller.java
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api.points;
+
+import com.loopers.application.points.PointsFacade;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/points")
+public class PointsV1Controller {
+
+    private final PointsFacade pointsFacade;
+
+    @PostMapping("/charge")
+    public ApiResponse<PointsV1Dto.PointsResponse> charge(
+            @RequestBody PointsV1Dto.PointsChargeRequest request
+    ) {
+        var info = pointsFacade.charge(request.loginId(), request.points());
+        var response = PointsV1Dto.PointsResponse.from(info);
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("")
+    public ApiResponse<PointsV1Dto.PointsResponse> get(
+            @RequestHeader("X-USER-ID") String loginId
+    ) {
+        var info = pointsFacade.get(loginId);
+        var response = PointsV1Dto.PointsResponse.from(info);
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/points/PointsV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/points/PointsV1Dto.java
@@ -1,0 +1,23 @@
+package com.loopers.interfaces.api.points;
+
+import com.loopers.application.points.PointsInfo;
+
+public class PointsV1Dto {
+    public record PointsResponse(
+            Long id, Long userId, Long points
+    ) {
+        public static PointsResponse from(PointsInfo info) {
+            return new PointsResponse(
+                    info.id(),
+                    info.userId(),
+                    info.amount()
+            );
+        }
+    }
+
+    public record PointsChargeRequest(
+            String loginId, Long points
+    ) {
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/users/UsersV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/users/UsersV1ApiSpec.java
@@ -1,0 +1,26 @@
+package com.loopers.interfaces.api.users;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Users V1 API", description = "회원가입, 내 정보 조회")
+public interface UsersV1ApiSpec {
+    @Operation(
+            summary = "회원가입",
+            description = "회원가입"
+    )
+    ApiResponse<UsersV1Dto.UsersResponse> register(
+            @Schema(name = "요청", description = "회원가입할 사용자 정보 입력")
+            UsersV1Dto.UsersRegisterRequest request
+    );
+
+    @Operation(
+            summary = "내 정보 조회",
+            description = "내 정보 조회"
+    )
+    ApiResponse<UsersV1Dto.UsersResponse> getMyInfo(
+            @Schema(name = "조회할 아이디", description = "X-USER-ID") String loginId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/users/UsersV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/users/UsersV1Controller.java
@@ -1,0 +1,41 @@
+package com.loopers.interfaces.api.users;
+
+import com.loopers.application.users.UsersFacade;
+import com.loopers.application.users.UsersInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.type.Gender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
+public class UsersV1Controller implements UsersV1ApiSpec {
+
+    private final UsersFacade usersFacade;
+
+    @PostMapping("")
+    @Override
+    public ApiResponse<UsersV1Dto.UsersResponse> register(
+            @RequestBody UsersV1Dto.UsersRegisterRequest request
+    ) {
+        UsersInfo info = usersFacade.register(
+                request.loginId(),
+                Gender.from(request.gender()),
+                request.birthDate(),
+                request.email());
+        UsersV1Dto.UsersResponse response = UsersV1Dto.UsersResponse.from(info);
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/me")
+    @Override
+    public ApiResponse<UsersV1Dto.UsersResponse> getMyInfo(
+            @RequestHeader("X-USER-ID") String loginId
+    ) {
+        UsersInfo info = usersFacade.getMyInfo(loginId);
+        UsersV1Dto.UsersResponse response = UsersV1Dto.UsersResponse.from(info);
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/users/UsersV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/users/UsersV1Dto.java
@@ -1,0 +1,25 @@
+package com.loopers.interfaces.api.users;
+
+import com.loopers.application.users.UsersInfo;
+
+public class UsersV1Dto {
+    public record UsersResponse(
+            Long id, String loginId, String gender, String birthDate, String email
+    ) {
+        public static UsersResponse from(UsersInfo info) {
+            return new UsersResponse(
+                info.id(),
+                info.loginId(),
+                info.gender(),
+                info.birthDate(),
+                info.email()
+            );
+        }
+    }
+
+
+    public record UsersRegisterRequest(
+            String loginId, String gender, String birthDate, String email
+    ) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/type/Gender.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/type/Gender.java
@@ -1,0 +1,30 @@
+package com.loopers.support.type;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.Getter;
+
+@Getter
+public enum Gender {
+    MALE("남"),
+    FEMALE("여"),
+    ;
+
+    private final String value;
+
+    Gender(String value) {
+        this.value = value;
+    }
+
+    public static Gender from(String value) {
+        if (value == null || value.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "성별은 비어있을 수 없습니다: " + value);
+        }
+        
+        return switch (value) {
+            case "남" -> MALE;
+            case "여" -> FEMALE;
+            default -> throw new CoreException(ErrorType.BAD_REQUEST, "지원하지 않는 성별입니다: " + value);
+        };
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/points/PointsModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/points/PointsModelTest.java
@@ -1,0 +1,32 @@
+package com.loopers.domain.points;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PointsModelTest {
+
+    @Nested
+    class Charge{
+        @DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다.")
+        @Test
+        void failsToChargePoints_whenAmountIsZeroOrNegative() {
+            // arrange
+            long testUserId = 1L;
+            var utd = PointsModel.from(testUserId);
+            long invalidAmount = -100;
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                utd.charge(invalidAmount);
+            });
+
+            // assert
+            assertEquals(ErrorType.BAD_REQUEST, exception.getErrorType());
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/points/PointsServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/points/PointsServiceTest.java
@@ -1,0 +1,92 @@
+package com.loopers.domain.points;
+
+import com.loopers.domain.users.UsersModel;
+import com.loopers.domain.users.UsersService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.type.Gender;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class PointsServiceTest {
+
+    @Autowired
+    private PointsService pointsService;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    private UsersService usersService;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("포인트 조회")
+    @Nested
+    class Get {
+
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.")
+        @Test
+        void getPoints_whenUserExists() {
+            // given
+            String loginId = "testUser";
+            UsersModel tester = usersService.register(
+                    loginId,
+                    Gender.MALE,
+                    "1993-04-09",
+                    "test@gmail.com"
+            );
+
+            // when
+            PointsModel points = pointsService.get(loginId);
+
+            // then
+            assertNotNull(points);
+            assertNotNull(points.getId());
+            assertNotNull(points.getAmount());
+            assertEquals(tester.getId(), points.getUserId());
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void getPoints_whenUserDoesNotExist() {
+            // given
+            String loginId = "nonExistentUser";
+
+            // when
+            PointsModel points = pointsService.get(loginId);
+
+            // then
+            assertNull(points);
+        }
+    }
+
+    @DisplayName("포인트 충전")
+    @Nested
+    class Charge {
+
+        @DisplayName("존재하지 않는 유저 ID 로 충전을 시도한 경우, 실패한다.")
+        @Test
+        void chargePoints_whenUserExists() {
+            // given
+            String loginId = "nonExistentUser";
+
+            // when
+            CoreException coreException = assertThrows(CoreException.class,
+                    () -> pointsService.charge(loginId, 100L));
+
+            // then
+            assertEquals(ErrorType.NOT_FOUND, coreException.getErrorType());
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/users/UsersModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/users/UsersModelTest.java
@@ -1,0 +1,70 @@
+package com.loopers.domain.users;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.type.Gender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UsersModelTest {
+    @Nested
+    class Create {
+        @DisplayName("ID 가 영문 및 숫자 10자 이내 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+        @Test
+        void failsToCreateUser_whenLoginIdIsInvalid() {
+            // arrange
+            String invalidLoginId = "invalid_login_id";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                UsersModel.of(invalidLoginId,
+                        Gender.MALE,
+                        "1993-04-09",
+                        "test@gmail.com");
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("이메일이 xx@yy.zz 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+        @Test
+        void failsToCreateUser_whenEmailIsInvalid() {
+            // arrange
+            String invalidEmail = "invalid_email_format";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                UsersModel.of("testUser",
+                        Gender.MALE,
+                        "1993-04-09",
+                        invalidEmail);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("생년월일이 yyyy-MM-dd 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+        @Test
+        void failsToCreateUser_whenBirthDateIsInvalid() {
+            // arrange
+            String invalidBirthDate = "19931230"; // 잘못된 날짜 형식
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                UsersModel.of("testUser",
+                        Gender.MALE,
+                        invalidBirthDate,
+                        "test@gmail.com");
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/users/UsersServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/users/UsersServiceTest.java
@@ -69,7 +69,7 @@ class UsersServiceTest {
             });
 
             // assert
-            assertEquals(exception.getErrorType(), ErrorType.CONFLICT);
+            assertEquals(ErrorType.CONFLICT, exception.getErrorType());
         }
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/users/UsersServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/users/UsersServiceTest.java
@@ -1,0 +1,119 @@
+package com.loopers.domain.users;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.support.type.Gender;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class UsersServiceTest {
+
+    @Autowired
+    private UsersService usersService;
+    @Autowired
+    private UsersRepository usersRepository;
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+    
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    @DisplayName("회원가입")
+    class register {
+        @Test
+        @DisplayName("회원 가입시 User 저장이 수행된다. ( spy 검증 )")
+        void saveUser_whenUserRegisters() {
+            var spyUsersRepository = spy(usersRepository);
+            UsersService spyUsersService = new UsersService(spyUsersRepository);
+
+            // act
+            UsersModel result = spyUsersService.register("testUser",
+                    Gender.MALE,
+                    "1993-04-09",
+                    "test@gmail.com");
+
+            // verify
+            verify(spyUsersRepository).existsByLoginId("testUser");
+            verify(spyUsersRepository).save(any(UsersModel.class));
+            assertNotNull(result);
+            assertEquals("testUser", result.getLoginId());
+        }
+
+        @Test
+        @DisplayName("이미 가입된 ID로 회원가입 시도 시, 실패한다.")
+        void failToRegister_whenLoginIdAlreadyExists() {
+            // arrange
+            usersService.register("testUser",
+                    Gender.MALE,
+                    "1993-04-09",
+                    "test@gmail.com");
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                usersService.register("testUser",
+                        Gender.FEMALE,
+                        "1993-04-09",
+                        "test@naver.com");
+            });
+
+            // assert
+            assertEquals(exception.getErrorType(), ErrorType.CONFLICT);
+        }
+    }
+
+    @Nested
+    @DisplayName("내 정보 조회")
+    class getMyInfo {
+        @Test
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.")
+        void returnsUserInfo_whenUserExists() {
+            // arrange
+            UsersModel expected = UsersModel.of("testUser",
+                    Gender.MALE,
+                    "1993-04-09",
+                    "test@gmail.com");
+            UsersModel savedUser = usersRepository.save(expected);
+            String loginId = savedUser.getLoginId();
+
+            // act
+            UsersModel result = usersService.getMyInfo(loginId);
+
+            // assert
+            assertAll(
+                () -> assertNotNull(result),
+                () -> assertNotNull(result.getId()),
+                () -> assertNotNull(result.getCreatedAt()),
+                () -> assertNotNull(result.getUpdatedAt()),
+                () -> assertEquals(expected.getLoginId(), result.getLoginId()),
+                () -> assertEquals(expected.getGender(), result.getGender()),
+                () -> assertEquals(expected.getBirthDate(), result.getBirthDate()),
+                () -> assertEquals(expected.getEmail(), result.getEmail())
+            );
+        }
+
+        @Test
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        void returnsNull_whenUserDoesNotExist() {
+            // arrange
+            String nonExistentLoginId = "nonExistentUser";
+
+            // act
+            UsersModel result = usersService.getMyInfo(nonExistentLoginId);
+
+            // assert
+            assertNull(result);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/PointsV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/PointsV1ApiE2ETest.java
@@ -1,0 +1,147 @@
+package com.loopers.interfaces.api;
+
+import com.loopers.domain.users.UsersService;
+import com.loopers.interfaces.api.points.PointsV1Dto;
+import com.loopers.support.type.Gender;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.MultiValueMapAdapter;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class PointsV1ApiE2ETest {
+
+    private static final Function<String, String> ENDPOINT = (subRoute) -> "/api/v1/points" + subRoute;
+
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+    private final UsersService usersService;
+
+    @Autowired
+    public PointsV1ApiE2ETest(
+            TestRestTemplate testRestTemplate,
+            DatabaseCleanUp databaseCleanUp,
+            UsersService usersService
+    ) {
+        this.testRestTemplate = testRestTemplate;
+        this.databaseCleanUp = databaseCleanUp;
+        this.usersService = usersService;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("포인트 충전")
+    @Nested
+    class Charge {
+        @DisplayName("존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.")
+        @Test
+        void returnsChargedPoints_whenUserChargesPoints() {
+            // arrange
+            String requestUrl = ENDPOINT.apply("/charge");
+            String loginId = "testuser";
+            var testUser = usersService.register(loginId, Gender.MALE, "1993-04-09", "test@gmail.com");
+            long pointsToCharge = 1000;
+            var request = new PointsV1Dto.PointsChargeRequest(loginId, pointsToCharge);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<PointsV1Dto.PointsResponse>> responseType = new ParameterizedTypeReference<>() {};
+            var response = testRestTemplate.exchange(
+                    requestUrl,
+                    HttpMethod.POST,
+                    new HttpEntity<>(request),
+                    responseType
+            );
+
+            // assert
+            assertTrue(response.getStatusCode().is2xxSuccessful());
+            assertNotNull(response.getBody());
+            assertEquals(testUser.getId(), response.getBody().data().userId());
+            assertEquals(request.points(), response.getBody().data().points());
+        }
+
+        @DisplayName("존재하지 않는 유저로 요청할 경우, 404 Not Found 응답을 반환한다.")
+        @Test
+        void returnsNotFound_whenUserDoesNotExist() {
+            // arrange
+            String requestUrl = ENDPOINT.apply("/charge");
+            String nonExistentUserId = "nonexistentuser";
+            long pointsToCharge = 1000;
+            var request = new PointsV1Dto.PointsChargeRequest(nonExistentUserId, pointsToCharge);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<PointsV1Dto.PointsResponse>> responseType = new ParameterizedTypeReference<>() {};
+            var response = testRestTemplate.exchange(
+                    requestUrl,
+                    HttpMethod.POST,
+                    new HttpEntity<>(request),
+                    responseType
+            );
+
+            // assert
+            assertTrue(response.getStatusCode().is4xxClientError());
+            assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        }
+    }
+
+    @DisplayName("포인트 조회")
+    @Nested
+    class Get {
+        @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.")
+        @Test
+        void returnsPoints_whenUserRequestsPoints() {
+            // arrange
+            String requestUrl = ENDPOINT.apply("");
+            String loginId = "testuser";
+            var testUser = usersService.register(loginId, Gender.MALE, "1993-04-09", "test@gmail.com");
+            var headers = new MultiValueMapAdapter<>(Map.of("X-USER-ID", List.of(loginId)));
+
+            // act
+            ParameterizedTypeReference<ApiResponse<PointsV1Dto.PointsResponse>> responseType = new ParameterizedTypeReference<>() {};
+            var response = testRestTemplate.exchange(
+                    requestUrl,
+                    HttpMethod.GET,
+                    new HttpEntity<>(null, headers),
+                    responseType
+            );
+
+            // assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(testUser.getId(), response.getBody().data().userId());
+            assertTrue(response.getBody().data().points() >= 0);
+        }
+
+        @DisplayName("X-USER-ID 헤더가 없을 경우, 400 Bad Request 응답을 반환한다.")
+        @Test
+        void returnsBadRequest_whenUserIdHeaderIsMissing() {
+            // arrange
+            String requestUrl = ENDPOINT.apply("");
+
+            // act
+            ParameterizedTypeReference<ApiResponse<PointsV1Dto.PointsResponse>> responseType = new ParameterizedTypeReference<>() {};
+            var response = testRestTemplate.exchange(
+                    requestUrl,
+                    HttpMethod.GET,
+                    new HttpEntity<>(null),
+                    responseType
+            );
+
+            // assert
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UsersV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UsersV1ApiE2ETest.java
@@ -1,8 +1,8 @@
-package com.loopers.interfaces.api.users;
+package com.loopers.interfaces.api;
 
 import com.loopers.domain.users.UsersModel;
 import com.loopers.infrastructure.users.UsersJpaRepository;
-import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.users.UsersV1Dto;
 import com.loopers.support.type.Gender;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.*;

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/users/UsersV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/users/UsersV1ApiE2ETest.java
@@ -1,0 +1,168 @@
+package com.loopers.interfaces.api.users;
+
+import com.loopers.domain.users.UsersModel;
+import com.loopers.infrastructure.users.UsersJpaRepository;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.type.Gender;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMapAdapter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class UsersV1ApiE2ETest {
+
+    private static final Function<String, String> ENDPOINT = (subRoute) -> "/api/v1/users" + subRoute;
+
+    private final TestRestTemplate testRestTemplate;
+    private final UsersJpaRepository jpaRepository;
+    private final DatabaseCleanUp databaseCleanUp;
+
+
+    @Autowired
+    public UsersV1ApiE2ETest(
+            TestRestTemplate testRestTemplate,
+            UsersJpaRepository jpaRepository,
+            DatabaseCleanUp databaseCleanUp
+    ) {
+        this.testRestTemplate = testRestTemplate;
+        this.jpaRepository = jpaRepository;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("POST /api/v1/users")
+    @Nested
+    class Register {
+        @DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsCreatedUser_whenRegistrationIsSuccessful() {
+            // arrange
+            String requestUrl = ENDPOINT.apply("");
+            UsersV1Dto.UsersRegisterRequest request = new UsersV1Dto.UsersRegisterRequest(
+                "testuser",
+                "남",
+                "1990-01-01",
+                "test@example.com"
+            );
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UsersV1Dto.UsersResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UsersV1Dto.UsersResponse>> response =
+                testRestTemplate.exchange(requestUrl, HttpMethod.POST, new HttpEntity<>(request), responseType);
+
+            System.out.println("Response Status: " + response.getStatusCode());
+            System.out.println("Response Body: " + response.getBody());
+
+            // assert
+            assertTrue(response.getStatusCode().is2xxSuccessful());
+            assertNotNull(response.getBody());
+            assertNotNull(response.getBody().data().id());
+            assertEquals(request.loginId(), response.getBody().data().loginId());
+            assertEquals(request.gender(), response.getBody().data().gender());
+            assertEquals(request.birthDate(), response.getBody().data().birthDate());
+            assertEquals(request.email(), response.getBody().data().email());
+        }
+
+        @DisplayName("회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.")
+        @Test
+        void throwsBadRequest_whenGenderIsInvalid() {
+            // arrange
+            String requestUrl = ENDPOINT.apply("");
+            UsersV1Dto.UsersRegisterRequest request = new UsersV1Dto.UsersRegisterRequest(
+                "testuser",
+                "",
+                "1990-01-01",
+                "test@example.com"
+            );
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UsersV1Dto.UsersResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UsersV1Dto.UsersResponse>> response =
+                testRestTemplate.exchange(requestUrl, HttpMethod.POST, new HttpEntity<>(request), responseType);
+
+            // assert
+            assertTrue(response.getStatusCode().is4xxClientError());
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        }
+    }
+
+    @DisplayName("GET /api/v1/users/me")
+    @Nested
+    class GetMyInfo {
+        @DisplayName("내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnsMyInfo_whenRequestIsSuccessful() {
+            // arrange
+            String requestUrl = ENDPOINT.apply("/me");
+            String loginId = "testuser";
+            UsersModel model = UsersModel.of(
+                    loginId,
+                    Gender.MALE,
+                    "1993-04-09",
+                    "test@gmail.com");
+            jpaRepository.save(model);
+            var headers = new MultiValueMapAdapter<>(Map.of("X-USER-ID", List.of(loginId)));
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UsersV1Dto.UsersResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UsersV1Dto.UsersResponse>> response =
+                    testRestTemplate.exchange(
+                            requestUrl,
+                            HttpMethod.GET,
+                            new HttpEntity<>(null, headers),
+                            responseType
+                    );
+
+            // assert
+            assertTrue(response.getStatusCode().is2xxSuccessful());
+            assertNotNull(response.getBody());
+            assertNotNull(response.getBody().data().id());
+            assertEquals(model.getLoginId(), response.getBody().data().loginId());
+            assertEquals(model.getGender().getValue(), response.getBody().data().gender());
+            assertEquals(model.getBirthDate(), response.getBody().data().birthDate());
+            assertEquals(model.getEmail(), response.getBody().data().email());
+        }
+
+        @DisplayName("존재하지 않는 ID 로 조회할 경우, 404 Not Found 응답을 반환한다.")
+        @Test
+        void throwsNotFound_whenUserDoesNotExist() {
+            // arrange
+            String requestUrl = ENDPOINT.apply("/me");
+            String nonExistentLoginId = "nonexistentuser";
+            var headers = new MultiValueMapAdapter<>(Map.of("X-USER-ID", List.of(nonExistentLoginId)));
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UsersV1Dto.UsersResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UsersV1Dto.UsersResponse>> response =
+                    testRestTemplate.exchange(
+                            requestUrl,
+                            HttpMethod.GET,
+                            new HttpEntity<>(null, headers),
+                            responseType
+                    );
+
+            // assert
+            assertTrue(response.getStatusCode().is4xxClientError());
+            assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        }
+
+    }
+}


### PR DESCRIPTION
## 📌 Summary

회원가입, 내 정보 조회, 포인트 충전, 포인트 조회 - 모델, 서비스, API

## 💬 Review Points

입력값을 넣을 때, 전달 객체를 어떻게 넘기는 것이 좋을까에 대해 고민이 많았습니다.

1. 데이터가 출력될 때는, 고수준 의존성의 객체를 저수준 의존성의 레이어(혹은 컴포넌트)로 보내는 것은 적절하면서도, 상태를 객체로묶어 한번에 옮기기에 적절했지만,
2. 데이터가 입력될 때는, 저수준 의존성의 객체를 고수준 의존성의 레이어로 보내는 것은, 고수준 레이어가 저수준을 참조하기에 문제가 크고, 그렇다면 고수준 객체를 저수준에서 생성해서 고수준으로 들어가야 하느냐는 고민에서,

2-1. 객체로 전달된 입력값을 여러 변수 또는 의존성 논외의 타입들로 쪼개어 전달
2-2. 고수준 객체를 생성자든 팩토리(혹은 정적 메서드 팩토리)든의 방법으로 전달
에서 고민이 되었습니다.

2-1은 의존성 문제에서 깔끔해지지만, 파라미터가 너무 많아지거나, 별도의 의존성 논외의 타입을 따로 만들어야 하는 단점이 있다고 생각하고
2-2는 코드가 상대적으로 깔끔해질 수 있겠지만, 고수준의 로직이 저수준 레이어에 드러나게 될 우려가 있는 단점이 있다고 생각합니다.
   (#e636a44fde862b844ba113fa16ca9813db095998, com.loopers.domain.users.UserService 호출 시그니처의 파라미터들)

2-1과 2-2 또는 다른 선호하시는 방식이 있으신가요? 또한 1번에 대해서도 고민되었던 예외 케이스가 있으셨는지 궁금합니다.

## ✅ Checklist

- [v]  테스트는 모두 통과해야 하며, `@Test` 기반으로 명시적으로 작성
- [v]  각 테스트는 테스트 명/설명/입력/예상 결과가 분명해야 함
- [v]  E2E 테스트는 실제 HTTP 요청을 통해 흐름을 검증할 것

## 📎 References

